### PR TITLE
Hotfix/docker

### DIFF
--- a/brickyard_modules/buildtask/install/package.json
+++ b/brickyard_modules/buildtask/install/package.json
@@ -10,13 +10,13 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "bower": "^1.8.0",
-    "fs-extra": "^3.0.1",
-    "gulp-json-editor": "^2.2.1",
-    "gulp-load-plugins": "^1.2.4",
-    "lodash": "^4.6.1"
+    "bower": "^1.8.4",
+    "fs-extra": "^6.0.1",
+    "gulp-json-editor": "^2.4.1",
+    "gulp-load-plugins": "^1.5.0",
+    "lodash": "^4.17.10"
   },
   "dependencies": {
-    "brickyard-cli": "^4.6.2"
+    "brickyard-cli": "^5.0.1"
   }
 }

--- a/lib/docker/dockerfile.backend
+++ b/lib/docker/dockerfile.backend
@@ -17,7 +17,7 @@ COPY --from=build-stage /brickyard-app/output/package.json ./package.json
 RUN apk add --no-cache python make g++ && npm i --production && npm cache clean --force && apk del python make g++
 COPY --from=build-stage /brickyard-app/output/ ./
 VOLUME /brickyard-app
-CMD node .
+CMD node . --brickyard-app-name="<%=plans%>"
 <%if (expose) {%>
 EXPOSE <%=expose%>
 <%}%>

--- a/lib/docker/dockerfile.backend
+++ b/lib/docker/dockerfile.backend
@@ -1,8 +1,10 @@
 FROM dbjtech/brickyard-cli:build-essential as build-stage
 
 WORKDIR /brickyard-app/
+<%if (!onlyDockerfile) {%>
 COPY <%=packageJsonPath%> ./package.json
 RUN npm i
+<%}%>
 COPY ./brickyard_modules ./brickyard_modules
 <%if (configPathExists) {%>
 COPY <%=configPath%> ./config.js

--- a/lib/docker/dockerfile.frontend
+++ b/lib/docker/dockerfile.frontend
@@ -1,8 +1,10 @@
 FROM dbjtech/brickyard-cli:build-essential as build-stage
 
 WORKDIR /brickyard-app/
+<%if (!onlyDockerfile) {%>
 COPY <%=packageJsonPath%> ./package.json
 RUN npm i
+<%}%>
 COPY ./brickyard_modules ./brickyard_modules
 <%if (configPathExists) {%>
 COPY <%=configPath%> ./config.js

--- a/lib/gulpfile.js
+++ b/lib/gulpfile.js
@@ -193,6 +193,7 @@ gulp.task('create-module', async () => {
 
 gulp.task('build-docker', async () => {
 	const { plan, dir, config, expose, tag } = argv
+	const onlyDockerfile = argv['only-dockerfile']
 	await scanAndPreparePlan()
 	await brickyard.saveAsync(dir, config)
 	brickyard.prepareDependencies()
@@ -200,10 +201,11 @@ gulp.task('build-docker', async () => {
 	const dockerfile = await docker.writeDockerfile(dir, brickyard.modules, {
 		plans: plan.join(' '),
 		configPath: config,
+		onlyDockerfile,
 		expose,
 		packageJson: brickyard.getPackageJson(),
 	})
-	if (!argv['only-dockerfile']) {
+	if (!onlyDockerfile) {
 		docker.runDockerBuild(dockerfile, tag)
 	}
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brickyard-cli",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "",
   "main": "lib/brickyard",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brickyard-cli",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "",
   "main": "lib/brickyard",
   "bin": {


### PR DESCRIPTION
* 升级brickyard-cli的依赖版本，不然老是去装gulp-data
* dockerfile的命令里，增加一个app name的参数，这样docker部署后，top能看出是什么程序。否则只有个“node .”
* 当执行brickyard build-docker xxx --only-dockerfile的时候，dockerfile里不在copy package.json。
  - copy的话是为了开发时能充分利用缓存。
  - 不copy的话则更适用于持续集成。