### PR TITLE
chore: update deps version of buildtask mocha

### DIFF
--- a/brickyard_modules/buildtask/test-mocha/package.json
+++ b/brickyard_modules/buildtask/test-mocha/package.json
@@ -11,9 +11,9 @@
   "license": "ISC",
   "devDependencies": {
     "gulp-exit": "0.0.2",
-    "gulp-mocha": "^3.0.1",
-    "lodash": "^4.15.0",
-    "mocha": "^3.0.2",
-    "should": "^11.1.0"
+    "gulp-mocha": "^6.0.0",
+    "lodash": "^4.17.10",
+    "mocha": "^5.2.0",
+    "should": "^13.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brickyard-cli",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "",
   "main": "lib/brickyard",
   "bin": {


### PR DESCRIPTION
更新一下单元测试的库（主要是should.js），否则新旧版一起用，全局的should变量会产生混乱。